### PR TITLE
Mkdocs update

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,9 @@ build:
   tools:
     python: "3.8"
 
+mkdocs:
+  configuration: mkdocs.yml
+
 python:
   install:
     - requirements: requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,10 @@
+version: 2
+
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "3.8"
+
+python:
+  install:
+    - requirements: requirements.txt

--- a/README.md
+++ b/README.md
@@ -17,3 +17,4 @@ Agradecemos infinitamente a todos los que han colaborado con la elaboración de 
 - Sergio Leiva (Chats del DCC)
 - Alejandra Alarcón (Burocracia Titulación)
 - Fran Zautzik (Actualización de información al 2023)
+- Christopher Marín (Migración de versiones y mantenimiento)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,2 +1,2 @@
-site_name: Howto CaDCC
+site_name: FAQ CaDCC
 theme: readthedocs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-mkdocs
+mkdocs==1.5.1


### PR DESCRIPTION
creado `.readthedocs.yaml` ([documentación](https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html))
configurado versión de mkdocs 1.5.1
cambiado nombre de proyecto en `mkdocs.yml`